### PR TITLE
add defaults with support for indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Fully close this feed.
 
 Calls the callback with `(err)` when all storage has been closed.
 
+#### `feed.defaults(opts)`
+
+Overwrite options set on initialization. Currently supported:
+
+* `opts.indexing` - change indexing value. `indexing: false` makes hyperdrive write files to storage when you write to the archive.
+
 #### `feed.on('ready')`
 
 Emitted when the feed is ready and all properties have been populated.

--- a/index.js
+++ b/index.js
@@ -102,6 +102,11 @@ inherits(Feed, events.EventEmitter)
 
 Feed.discoveryKey = crypto.discoveryKey
 
+Feed.prototype.defaults = function (opts) {
+  if (!opts) return
+  this._indexing = !!opts.indexing
+}
+
 Feed.prototype.replicate = function (opts) {
   // Lazy load replication deps
   if (!replicate) replicate = require('./lib/replicate')


### PR DESCRIPTION
Part one of fixing our indexing issue. Adds `feed.defaults(opts)` to change the indexing option. 

Are there any options I should add in here? Didn't see anything that jumped out.