### PR TITLE
Test using random-access-file not random-access-memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "speedometer": "^1.0.0",
     "standard": "^8.6.0",
     "stream-collector": "^1.0.1",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "tmp": "0.0.33"
   },
   "optionalDependencies": {
     "fd-lock": "^1.0.2"

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -1,6 +1,7 @@
 var hypercore = require('../..')
-var ram = require('random-access-memory')
+var tmp = require('tmp')
 
 module.exports = function create (key, opts) {
-  return hypercore(ram, key, opts)
+  var tmpobj = tmp.dirSync({unsafeCleanup: true})
+  return hypercore(tmpobj.name, key, opts)
 }


### PR DESCRIPTION
Switch to using random-access-file in tests, in order to test in an environment more similar to actual use and catch unusual filesystem related bugs that can crop up on Windows etc.