### PR TITLE
test filesystem compatibility, esp for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
   "devDependencies": {
     "nyc": "^13.1.0",
     "random-access-memory": "^3.1.0",
+    "rimraf": "^2.6.3",
     "shuffle-array": "^1.0.1",
     "speedometer": "^1.0.0",
     "standard": "^8.6.0",
     "stream-collector": "^1.0.1",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "tmp": "^0.1.0"
   },
   "optionalDependencies": {
     "fd-lock": "^1.0.2"

--- a/test/audit.js
+++ b/test/audit.js
@@ -1,5 +1,6 @@
 var tape = require('tape')
 var create = require('./helpers/create')
+var cleanup = require('./helpers/cleanup')
 
 tape('basic audit', function (t) {
   var feed = create()
@@ -9,7 +10,7 @@ tape('basic audit', function (t) {
     feed.audit(function (err, report) {
       t.error(err, 'no error')
       t.same(report, { valid: 2, invalid: 0 })
-      t.end()
+      cleanup(feed, t)
     })
   })
 })
@@ -28,7 +29,7 @@ tape('basic audit with bad data', function (t) {
         feed.audit(function (err, report) {
           t.error(err, 'no error')
           t.same(report, { valid: 1, invalid: 0 })
-          t.end()
+          cleanup(feed, t)
         })
       })
     })

--- a/test/helpers/cleanup.js
+++ b/test/helpers/cleanup.js
@@ -1,0 +1,7 @@
+var rimraf = require('rimraf')
+
+module.exports = function (feed, t) {
+  rimraf(feed._storage.data.directory, function () {
+    t.end()
+  })
+}

--- a/test/helpers/create.js
+++ b/test/helpers/create.js
@@ -1,6 +1,8 @@
 var hypercore = require('../..')
-var ram = require('random-access-memory')
+var tmp = require('tmp')
 
 module.exports = function create (key, opts) {
-  return hypercore(ram, key, opts)
+  var tmpobj = tmp.dirSync({unsafeCleanup: true})
+  var feed = hypercore(tmpobj.name, key, opts)
+  return feed
 }


### PR DESCRIPTION
Switch to using random-access-file in tests, in order to test in an environment more similar to actual use and catch unusual filesystem related bugs that can crop up on Windows etc.

This also cleans up files after creating them, superseding https://github.com/mafintosh/hypercore/pull/209