### PR TITLE
Add batch support in createReadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Options include:
   live: false, // set to true to keep reading forever
   timeout: 0, // timeout for each data event (0 means no timeout)
   wait: true // wait for data to be downloaded
+  batch: 1 // amount of messages to read in batch, increasing it (e.g. 100) can improve the performance reading
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Options include:
   tail: false, // sets `start` to `feed.length`
   live: false, // set to true to keep reading forever
   timeout: 0, // timeout for each data event (0 means no timeout)
-  wait: true // wait for data to be downloaded
+  wait: true, // wait for data to be downloaded
   batch: 1 // amount of messages to read in batch, increasing it (e.g. 100) can improve the performance reading
 }
 ```

--- a/bench/all.sh
+++ b/bench/all.sh
@@ -26,6 +26,9 @@ run () {
   echo '> node read-64kb-blocks-linear.js'
   node read-64kb-blocks-linear.js
   echo
+  echo '> node read-64kb-blocks-linear-batch.js'
+  node read-64kb-blocks-linear-batch.js
+  echo
   echo '> node read-64kb-blocks-proof.js'
   node read-64kb-blocks-proof.js
   echo

--- a/bench/read-64kb-blocks-linear-batch.js
+++ b/bench/read-64kb-blocks-linear-batch.js
@@ -1,0 +1,18 @@
+var path = require('path')
+var hypercore = require('../')
+
+var feed = hypercore(path.join(__dirname, 'cores/64kb'))
+
+var then = Date.now()
+var size = 0
+var cnt = 0
+
+feed.createReadStream({ batch: 100 })
+  .on('data', function (data) {
+    size += data.length
+    cnt++
+  })
+  .on('end', function () {
+    console.log(Math.floor(1000 * size / (Date.now() - then)) + ' bytes/s')
+    console.log(Math.floor(1000 * cnt / (Date.now() - then)) + ' blocks/s')
+  })

--- a/index.js
+++ b/index.js
@@ -1308,10 +1308,8 @@ Feed.prototype.createReadStream = function (opts) {
   var live = !!opts.live
   var snapshot = opts.snapshot !== false
   var batch = opts.batch || 1
-  var batchResults = []
   var batchEnd = 0
   var batchLimit = 0
-  var batchIndex = 0
 
   var first = true
   var range = this.download({start: start, end: end, linear: true})
@@ -1332,10 +1330,6 @@ Feed.prototype.createReadStream = function (opts) {
       first = false
     }
 
-    if (batchResults.length > 0 && batchIndex < batchResults.length) {
-      return cb(null, batchResults[batchIndex++])
-    }
-
     if (start === end || (end === -1 && start === self.length)) {
       return cb(null, null)
     }
@@ -1345,7 +1339,6 @@ Feed.prototype.createReadStream = function (opts) {
       return
     }
 
-    batchIndex = 0
     batchEnd = start + batch
     batchLimit = end === Infinity ? self.length : end
     if (batchEnd > batchLimit) {
@@ -1363,8 +1356,11 @@ Feed.prototype.createReadStream = function (opts) {
         return
       }
 
-      batchResults = result
-      cb(null, batchResults[batchIndex++])
+      var lastIdx = result.length - 1
+      for (var i = 0; i < lastIdx; i++) {
+        this.push(result[i])
+      }
+      cb(null, result[lastIdx])
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -1378,13 +1378,13 @@ Feed.prototype.createReadStream = function (opts) {
   }
 
   function setStart (value) {
-    var _start = start
+    var prevStart = start
     start = value
     range.start = start
     if (range.iterator) {
       range.iterator.start = start
     }
-    return _start
+    return prevStart
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1309,7 +1309,6 @@ Feed.prototype.createReadStream = function (opts) {
   var snapshot = opts.snapshot !== false
   var batch = opts.batch || 1
   var batchResults = []
-  var batchStart = 0
   var batchEnd = 0
   var batchLimit = 0
   var batchIndex = 0
@@ -1347,21 +1346,20 @@ Feed.prototype.createReadStream = function (opts) {
     }
 
     batchIndex = 0
-    batchEnd = batchStart + batch
+    batchEnd = start + batch
     batchLimit = end === Infinity ? self.length : end
     if (batchEnd > batchLimit) {
       batchEnd = batchLimit
     }
-    batchStart = setStart(batchEnd)
 
-    if (batchStart === batchEnd) {
-      self.get(setStart(batchStart + 1), opts, cb)
+    if (!self.downloaded(start, batchEnd)) {
+      self.get(setStart(start + 1), opts, cb)
       return
     }
 
-    self.getBatch(batchStart, batchEnd, opts, (err, result) => {
+    self.getBatch(setStart(batchEnd), batchEnd, opts, (err, result) => {
       if (err || result.length === 0) {
-        self.get(setStart(batchStart + 1), opts, cb)
+        cb(err)
         return
       }
 

--- a/index.js
+++ b/index.js
@@ -1346,7 +1346,7 @@ Feed.prototype.createReadStream = function (opts) {
     }
 
     batchIndex = 0
-    nextBatchStart += batch
+    nextBatchStart = start + batch
     batchEnd = end === Infinity ? self.length : end
     if (nextBatchStart >= batchEnd) {
       batch = 1

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "fd-lock": false
   },
   "scripts": {
-    "test": "standard && tape test/*.js",
-    "cov": "nyc tape test/*.js",
+    "test": "standard && tape test/streams.js",
+    "cov": "nyc tape test/streams.js",
     "bench": "cd bench && ./all.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "fd-lock": false
   },
   "scripts": {
-    "test": "standard && tape test/streams.js",
-    "cov": "nyc tape test/streams.js",
+    "test": "standard && tape test/*.js",
+    "cov": "nyc tape test/*.js",
     "bench": "cd bench && ./all.sh"
   },
   "repository": {

--- a/test/streams.js
+++ b/test/streams.js
@@ -3,121 +3,126 @@ var collect = require('stream-collector')
 var create = require('./helpers/create')
 var bufferFrom = require('buffer-from')
 
-tape('createReadStream to createWriteStream', function (t) {
-  var feed1 = create()
-  var feed2 = create()
+function test (batch = 1) {
+  tape('createReadStream to createWriteStream', function (t) {
+    var feed1 = create()
+    var feed2 = create()
 
-  feed1.append(['hello', 'world'], function () {
-    var r = feed1.createReadStream()
-    var w = feed2.createWriteStream()
+    feed1.append(['hello', 'world'], function () {
+      var r = feed1.createReadStream({ batch })
+      var w = feed2.createWriteStream()
 
-    r.pipe(w).on('finish', function () {
-      collect(feed2.createReadStream(), function (err, data) {
+      r.pipe(w).on('finish', function () {
+        collect(feed2.createReadStream({ batch }), function (err, data) {
+          t.error(err, 'no error')
+          t.same(data, [bufferFrom('hello'), bufferFrom('world')])
+          t.end()
+        })
+      })
+    })
+  })
+
+  tape('createReadStream with start, end', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
+
+    feed.append(['hello', 'multiple', 'worlds'], function () {
+      collect(feed.createReadStream({start: 1, end: 2, batch}), function (err, data) {
         t.error(err, 'no error')
-        t.same(data, [bufferFrom('hello'), bufferFrom('world')])
+        t.same(data, ['multiple'])
         t.end()
       })
     })
   })
-})
 
-tape('createReadStream with start, end', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
+  tape('createReadStream with start, no end', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
 
-  feed.append(['hello', 'multiple', 'worlds'], function () {
-    collect(feed.createReadStream({start: 1, end: 2}), function (err, data) {
-      t.error(err, 'no error')
-      t.same(data, ['multiple'])
-      t.end()
+    feed.append(['hello', 'multiple', 'worlds'], function () {
+      collect(feed.createReadStream({start: 1, batch}), function (err, data) {
+        t.error(err, 'no error')
+        t.same(data, ['multiple', 'worlds'])
+        t.end()
+      })
     })
   })
-})
 
-tape('createReadStream with start, no end', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
+  tape('createReadStream with no start, end', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
 
-  feed.append(['hello', 'multiple', 'worlds'], function () {
-    collect(feed.createReadStream({start: 1}), function (err, data) {
-      t.error(err, 'no error')
-      t.same(data, ['multiple', 'worlds'])
-      t.end()
+    feed.append(['hello', 'multiple', 'worlds'], function () {
+      collect(feed.createReadStream({end: 2, batch}), function (err, data) {
+        t.error(err, 'no error')
+        t.same(data, ['hello', 'multiple'])
+        t.end()
+      })
     })
   })
-})
 
-tape('createReadStream with no start, end', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
+  tape('createReadStream with live: true', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
+    var expected = ['a', 'b', 'c', 'd', 'e']
 
-  feed.append(['hello', 'multiple', 'worlds'], function () {
-    collect(feed.createReadStream({end: 2}), function (err, data) {
-      t.error(err, 'no error')
-      t.same(data, ['hello', 'multiple'])
-      t.end()
+    t.plan(expected.length)
+
+    var rs = feed.createReadStream({live: true, batch})
+
+    rs.on('data', function (data) {
+      t.same(data, expected.shift())
+    })
+
+    rs.on('end', function () {
+      t.fail('should never end')
+    })
+
+    feed.append('a', function () {
+      feed.append('b', function () {
+        feed.append(['c', 'd', 'e'])
+      })
     })
   })
-})
 
-tape('createReadStream with live: true', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
-  var expected = ['a', 'b', 'c', 'd', 'e']
+  tape('createReadStream with live: true after append', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
+    var expected = ['a', 'b', 'c', 'd', 'e']
 
-  t.plan(expected.length)
+    t.plan(expected.length)
 
-  var rs = feed.createReadStream({live: true})
+    feed.append(['a', 'b'], function () {
+      var rs = feed.createReadStream({live: true, batch})
 
-  rs.on('data', function (data) {
-    t.same(data, expected.shift())
-  })
+      rs.on('data', function (data) {
+        t.same(data, expected.shift())
+      })
 
-  rs.on('end', function () {
-    t.fail('should never end')
-  })
+      rs.on('end', function () {
+        t.fail('should never end')
+      })
 
-  feed.append('a', function () {
-    feed.append('b', function () {
       feed.append(['c', 'd', 'e'])
     })
   })
-})
 
-tape('createReadStream with live: true after append', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
-  var expected = ['a', 'b', 'c', 'd', 'e']
+  tape('createReadStream with live: true and tail: true', function (t) {
+    var feed = create({valueEncoding: 'utf-8'})
+    var expected = ['c', 'd', 'e']
 
-  t.plan(expected.length)
+    t.plan(expected.length)
 
-  feed.append(['a', 'b'], function () {
-    var rs = feed.createReadStream({live: true})
+    feed.append(['a', 'b'], function () {
+      var rs = feed.createReadStream({live: true, tail: true, batch})
 
-    rs.on('data', function (data) {
-      t.same(data, expected.shift())
+      rs.on('data', function (data) {
+        t.same(data, expected.shift())
+      })
+
+      rs.on('end', function () {
+        t.fail('should never end')
+      })
+
+      feed.append(['c', 'd', 'e'])
     })
-
-    rs.on('end', function () {
-      t.fail('should never end')
-    })
-
-    feed.append(['c', 'd', 'e'])
   })
-})
+}
 
-tape('createReadStream with live: true and tail: true', function (t) {
-  var feed = create({valueEncoding: 'utf-8'})
-  var expected = ['c', 'd', 'e']
-
-  t.plan(expected.length)
-
-  feed.append(['a', 'b'], function () {
-    var rs = feed.createReadStream({live: true, tail: true})
-
-    rs.on('data', function (data) {
-      t.same(data, expected.shift())
-    })
-
-    rs.on('end', function () {
-      t.fail('should never end')
-    })
-
-    feed.append(['c', 'd', 'e'])
-  })
-})
+test()
+test(10)


### PR DESCRIPTION
It adds support for batch reading in createReadStream and improve the performance.

It's an initial idea and feedback is welcome.

#### Usage

```javascript
feed.createReadStream({ batch: 100 }) // read batch of 100 messages
```

#### Benchmark

```
> node read-64kb-blocks-linear.js
685658891 bytes/s
10448 blocks/s

> node read-64kb-blocks-linear-batch.js // batch 100 
1080223162 bytes/s
16384 blocks/s
```

#### Todo

- [x] Add test (probably I will use the same tests that we use to test createReadStream)