### PR TITLE
Fix replication benchmarks

### DIFF
--- a/bench/replicate-16kb-blocks.js
+++ b/bench/replicate-16kb-blocks.js
@@ -14,6 +14,6 @@ source.ready(function () {
 })
 
 function replicate (a, b) {
-  var s = a.replicate()
-  return s.pipe(b.replicate()).pipe(s)
+  var s = a.replicate(false)
+  return s.pipe(b.replicate(true)).pipe(s)
 }

--- a/bench/replicate-64kb-blocks.js
+++ b/bench/replicate-64kb-blocks.js
@@ -14,6 +14,6 @@ source.ready(function () {
 })
 
 function replicate (a, b) {
-  var s = a.replicate()
-  return s.pipe(b.replicate()).pipe(s)
+  var s = a.replicate(false)
+  return s.pipe(b.replicate(true)).pipe(s)
 }


### PR DESCRIPTION
These were broken since commit a4e5142 corresponding to the v8.0.0 release. Hypercore-protocol version was bumped to 7, which requires the addition of the `initiator` parameter for replication.

