### PR TITLE
Make peer._remoteOpened public

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -58,6 +58,7 @@ function Peer (feed, opts) {
   this.remoteWant = false
   this.remoteTree = null
   this.remoteAck = false
+  this.remoteOpened = false
   this.live = !!opts.live
   this.sparse = feed.sparse
   this.ack = !!opts.ack
@@ -76,7 +77,6 @@ function Peer (feed, opts) {
   this.inflightWants = 0
 
   this._openTimeout = null
-  this._remoteOpened = false
   this._index = -1
   this._lastBytes = 0
   this._first = true
@@ -506,7 +506,7 @@ Peer.prototype._update = function () {
 Peer.prototype.onopen = function () {
   clearTimeout(this._openTimeout)
   this.feed.ifAvailable.continue()
-  this._remoteOpened = true
+  this.remoteOpened = true
 
   this._updateOptions()
 
@@ -574,7 +574,7 @@ Peer.prototype._close = function () {
   for (i = 0; i < this.inflightWants; i++) {
     this.feed.ifAvailable.continue()
   }
-  if (!this._remoteOpened) {
+  if (!this.remoteOpened) {
     this.feed.ifAvailable.continue()
   }
 }
@@ -591,7 +591,7 @@ Peer.prototype._sendWantsMaybe = function () {
 }
 
 Peer.prototype._sendWants = function () {
-  if (!this.wants || !this.downloading || !this._remoteOpened || !this.remoteUploading) return
+  if (!this.wants || !this.downloading || !this.remoteOpened || !this.remoteUploading) return
   if (this.inflightWants >= 16) return
 
   var i


### PR DESCRIPTION
Need to use this property to filter peers that are added but don't have the capability.