### PR TITLE
Exposing .codecs to turn a given config into a codec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Per default hypercore uses [random-access-file](https://github.com/mafintosh/ran
 
 You can also set valueEncoding to any [abstract-encoding](https://github.com/mafintosh/abstract-encoding) instance.
 
+Using `hypercore.codecs(codec)` you can manually lookup the `abstract-encoding` for a given input.
+
 __Note:__ The `[key]` and `secretKey` are _Node.js_ buffer instances, not browser-based ArrayBuffer instances. When creating hypercores in browser, if you pass an ArrayBuffer instance, you will get an error similar to `key must be at least 16, was given undefined`. Instead, create a Node.js Buffer instance using [Feross‘s](https://github.com/feross) [buffer](https://github.com/feross/buffer) module (`npm install buffer`). e.g.,
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -163,6 +163,7 @@ function Feed (createStorage, key, opts) {
 inherits(Feed, Nanoresource)
 
 Feed.discoveryKey = crypto.discoveryKey
+Feed.codecs = toCodec
 
 Feed.prototype[inspect] = function (depth, opts) {
   var indent = ''

--- a/test/value-encoding.js
+++ b/test/value-encoding.js
@@ -1,5 +1,7 @@
 var tape = require('tape')
 var create = require('./helpers/create')
+var hypercore = require('../')
+var codecs = require('codecs')
 
 tape('basic value encoding', function (t) {
   var feed = create({
@@ -49,4 +51,9 @@ tape('value encoding write-stream', function (t) {
       t.end()
     })
   })
+})
+
+tape('value encoding is exposed', function (t) {
+  t.equals(hypercore.codecs('json'), codecs('ndjson'))
+  t.end()
 })


### PR DESCRIPTION
This PR exposes the internal `toCodec` function, adds documentation and a simple test for it.

I noticed in [`crypto-encoder`](https://github.com/ameba23/crypto-encoder/blob/master/index.js#L54) that it contains a poor re-implementations of the `toCodec` function used internally in hypercore. As it is not quite equal to the `codecs` package I thought it would be a good idea to expose it, in order for packages like `crypto-encoder` to integrate more smoothly into the ecosystem.