### PR TITLE
Add byteLength param to upload/download events

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,11 +512,11 @@ Emitted when the feed is ready and all properties have been populated.
 
 Emitted when the feed experiences a critical error.
 
-#### `feed.on('download', index, data)`
+#### `feed.on('download', index, data, byteLength)`
 
 Emitted when a data block has been downloaded.
 
-#### `feed.on('upload', index, data)`
+#### `feed.on('upload', index, data, byteLength)`
 
 Emitted when a data block is going to be uploaded.
 

--- a/index.js
+++ b/index.js
@@ -1072,7 +1072,7 @@ Feed.prototype._writeDone = function (index, data, nodes, from, cb) {
         this._stats.downloadedBlocks += 1
         this._stats.downloadedBytes += data.length
       }
-      this.emit('download', index, data, from)
+      this.emit('download', index, data, data.length)
     }
     if (this.peers.length) this._announce({ start: index }, from)
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -209,7 +209,7 @@ Peer.prototype.onrequest = function (request) {
           self.feed._stats.uploadedBlocks += 1
           self.feed._stats.uploadedBytes += value.length
         }
-        self.feed.emit('upload', request.index, value, self)
+        self.feed.emit('upload', request.index, value, value.length)
       }
 
       // TODO: prob not needed with new bitfield

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -459,6 +459,35 @@ tape('allow push', function (t) {
   })
 })
 
+tape('download/upload event params', function (t) {
+  t.plan(13)
+
+  var feed = create()
+
+  feed.on('ready', function () {
+    var clone = create(feed.key)
+
+    var items = ['a', 'b', 'c']
+
+    clone.on('download', function (seq, data, byteLength) {
+      t.same(items[seq], data.toString('utf8'), 'expected data')
+      t.same(byteLength, 1, 'expected byte length')
+    })
+
+    feed.on('upload', function (seq, data, byteLength) {
+      t.same(items[seq], data.toString('utf8'), 'expected data')
+      t.same(byteLength, 1, 'expected byte length')
+    })
+
+    feed.append(items)
+
+    replicate(feed, clone, { live: true })
+    clone.download({ start: 0, end: 3 }, function (err) {
+      t.ok(!err, 'no error')
+    })
+  })
+})
+
 tape('shared stream, non live', function (t) {
   var a = create()
   var b = create()


### PR DESCRIPTION
This keeps us equiv to https://github.com/hypercore-protocol/hyperspace/pull/17

There was an undocumented `Peer` parameter being emitted as param 3. That might be a good idea to bring back in the future, but because it wasn't documented and we have no official software that depends on it -- and we already made the decision with remotehypercore in hyperspace -- we're clobbering that param.