### PR TITLE
Update: new peer-ack event

### DIFF
--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -301,6 +301,8 @@ Peer.prototype._onrequesttimeout = function () {
 }
 
 Peer.prototype.onhave = function (have) {
+  this.feed.emit('peer-ack', this, have)
+
   if (this.ack && have.ack && !have.bitfield && this.feed.bitfield.get(have.start)) {
     this.stream.stream.emit('ack', have)
     return


### PR DESCRIPTION
This PR adds a new event `peer-ack`. It is emitted when `onhave` is called.

Some of the background context for this PR: https://discord.com/channels/709519409932140575/709522073344540804/809152544554483753

In summary, this can be used to know when a peer has something new. This can be useful in the context of clients and seeders.

Related to: RangerMauve/hyperdrive-publisher#10