### PR TITLE
feature: onfeedauthenticate to authenticate single feeds per stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ Options include:
   keyPair: { publicKey, secretKey }, // use this keypair for Noise authentication
   onauthenticate (remotePublicKey, done) // hook that can be used to authenticate the remote peer.
                                          // calling done with an error will disallow the peer from connecting to you.
+  onfeedauthenticate (feed, remotePublicKey, done) // hook similar to onauthenticate but called per feed to replicate over a stream of feeds.
+                                                   // calling done with an error will disallow the peer from syncing this particular feed, but the
+                                                   // stream will stay open.
 }
 ```
 

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -30,6 +30,44 @@ function replicate (feed, initiator, opts) {
     if (stream.destroyed) return
     if (stream.opened(feed.key)) return
 
+    if (opts.noise !== false && opts.onfeedauthenticate) {
+      if (!stream.remotePublicKey) {
+        feed.ifAvailable.wait()
+        stream.setMaxListeners(0)
+        stream.on('close', onhandshake)
+        stream.on('handshake', onhandshake)
+        return
+      }
+      feedauthenticate()
+      return
+    }
+    replicatePeer()
+  }
+
+  function onhandshake () {
+    feed.ifAvailable.continue()
+    stream.off('close', onhandshake)
+    stream.off('handshake', onhandshake)
+    feedauthenticate()
+  }
+
+  function feedauthenticate () {
+    if (stream.destroyed) return
+    if (stream.opened(feed.key)) return
+    feed.ifAvailable.wait()
+    opts.onfeedauthenticate(feed, stream.remotePublicKey, function (err) {
+      feed.ifAvailable.continue()
+      if (stream.destroyed) return
+      if (stream.opened(feed.key)) return
+      if (err) {
+        stream.close(feed.discoveryKey)
+        return
+      }
+      replicatePeer()
+    })
+  }
+
+  function replicatePeer () {
     if (opts.noise !== false) {
       if (stream.remoteOpened(feed.key) && !stream.remoteVerified(feed.key)) {
         stream.close(feed.discoveryKey)


### PR DESCRIPTION
Having a stream authentication is super-useful but it may be warranted to authenticate particular feeds to particular peers while others are supposed to work. The proposed API in this PR should work without much overhead, allowing to disable the replication for particular feeds.