### PR TITLE
fixing replicating event to only emit when actually replicating

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,9 +227,7 @@ Feed.prototype.replicate = function (initiator, opts) {
   opts.stats = !!this._stats
   opts.noise = !(opts.noise === false && opts.encrypted === false)
 
-  var stream = replicate(this, initiator, opts)
-  this.emit('replicating', stream)
-  return stream
+  return replicate(this, initiator, opts)
 }
 
 Feed.prototype.registerExtension = function (name, handlers) {

--- a/lib/replicate.js
+++ b/lib/replicate.js
@@ -44,6 +44,7 @@ function replicate (feed, initiator, opts) {
 
     stream.setMaxListeners(0)
     peer.ready()
+    feed.emit('replicating', stream)
   }
 }
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -813,6 +813,43 @@ tape('double replicate', function (t) {
   })
 })
 
+tape('events: replicating events fired (normal)', function (t) {
+  var feed = create()
+  t.plan(1)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  feed.replicate(true).on('end', function () {
+    t.end()
+  })
+})
+
+tape('events: replicating events once for multiple feeds', function (t) {
+  var feed = create()
+  var stream = new Protocol(true)
+  t.plan(1)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  feed.replicate(stream)
+  feed.replicate(stream)
+  feed.on('end', function () {
+    t.end()
+  })
+})
+
+tape('events: replicating events not fired if canceled before ready', function (t) {
+  var feed = create()
+  var stream = new Protocol(true)
+  t.plan(0)
+  feed.on('replicating', () => {
+    t.pass('replicating')
+  })
+  stream.destroy()
+  feed.replicate(stream, { live: true })
+  t.end()
+})
+
 tape('regression: replicate without timeout', function (t) {
   t.plan(10)
 


### PR DESCRIPTION
Prior to this PR, the replicating event was emitted whenever `replicate` was called, with this PR its only emitted if the replication is actually happening.