### PR TITLE
Assign err to const so it's not gc'ed

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -37,6 +37,7 @@ module.exports = class Core {
     try {
       return await this.resume(oplogFile, treeFile, bitfieldFile, dataFile, opts)
     } catch (err) {
+      const e = err
       return new Promise((resolve, reject) => {
         let missing = 4
 
@@ -46,7 +47,7 @@ module.exports = class Core {
         dataFile.close(done)
 
         function done () {
-          if (--missing === 0) reject(err)
+          if (--missing === 0) reject(e)
         }
       })
     }


### PR DESCRIPTION
Hermes' overly aggressive garbage collector collects err before it's used because
it's not used immediately. Prevent this behavior by assigning err to const.