### PR TITLE
use Protomux.from() instead of new Protomux()

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = class Hypercore extends EventEmitter {
     if (!noiseStream) throw BAD_ARGUMENT('Invalid stream')
 
     if (!noiseStream.userData) {
-      const protocol = new Protomux(noiseStream)
+      const protocol = Protomux.from(noiseStream)
 
       if (opts.ondiscoverykey) {
         protocol.pair({ protocol: 'hypercore/alpha' }, opts.ondiscoverykey)


### PR DESCRIPTION
This PR along with https://github.com/mafintosh/protomux/pull/5 should obsolete https://github.com/hypercore-protocol/corestore/pull/27