### PR TITLE
Fix linear downloads due to bitfield indexing bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hypercore-crypto": "^3.2.1",
     "is-options": "^1.0.1",
     "protomux": "^3.4.0",
-    "quickbit-universal": "^1.2.1",
+    "quickbit-universal": "^1.2.2",
     "random-access-file": "^4.0.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hypercore-crypto": "^3.2.1",
     "is-options": "^1.0.1",
     "protomux": "^3.4.0",
-    "quickbit-universal": "^1.2.2",
+    "quickbit-universal": "^1.2.3",
     "random-access-file": "^4.0.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -880,3 +880,24 @@ test('replicate to writable cores after clearing', async function (t) {
 
   t.alike(c, b4a.from('c'))
 })
+
+test('large linear download', async function (t) {
+  const n = 1000
+
+  const a = await create()
+
+  for (let i = 0; i < n; i++) await a.append(i.toString())
+
+  const b = await create(a.key)
+
+  let d = 0
+  b.on('download', () => d++)
+
+  replicate(a, b, t)
+
+  const r = b.download({ start: 0, end: n, linear: true })
+
+  await r.done()
+
+  t.is(d, 1000)
+})


### PR DESCRIPTION
The test case fails when the index is used for linear range downloads. Working on a fix in https://github.com/holepunchto/libquickbit/pull/3.