### PR TITLE
Implement remote bitfield indexing

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -1,6 +1,6 @@
 const BigSparseArray = require('big-sparse-array')
 const b4a = require('b4a')
-const quickbit = require('quickbit-universal')
+const quickbit = require('./compat').quickbit
 
 const BITS_PER_PAGE = 2097152
 const BYTES_PER_PAGE = BITS_PER_PAGE / 8

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -4,6 +4,7 @@ const quickbit = require('quickbit-universal')
 
 const BITS_PER_PAGE = 2097152
 const BYTES_PER_PAGE = BITS_PER_PAGE / 8
+const WORDS_PER_PAGE = BYTES_PER_PAGE / 4
 
 class BitfieldPage {
   constructor (index, bitfield) {
@@ -51,11 +52,11 @@ module.exports = class Bitfield {
 
     const all = this.resumed
       ? new Uint32Array(buf.buffer, buf.byteOffset, Math.floor(buf.byteLength / 4))
-      : new Uint32Array(BITS_PER_PAGE / 32)
+      : new Uint32Array(WORDS_PER_PAGE)
 
-    for (let i = 0; i < all.length; i += BITS_PER_PAGE / 32) {
-      const bitfield = ensureSize(all.subarray(i, i + (BITS_PER_PAGE / 32)), BITS_PER_PAGE / 32)
-      const page = new BitfieldPage(i / (BITS_PER_PAGE / 32), bitfield)
+    for (let i = 0; i < all.length; i += WORDS_PER_PAGE) {
+      const bitfield = ensureSize(all.subarray(i, i + (WORDS_PER_PAGE)), WORDS_PER_PAGE)
+      const page = new BitfieldPage(i / (WORDS_PER_PAGE), bitfield)
       this._pages.set(page.index, page)
     }
   }
@@ -76,7 +77,7 @@ module.exports = class Bitfield {
     let p = this._pages.get(i)
 
     if (!p && val) {
-      p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32)))
+      p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(WORDS_PER_PAGE)))
     }
 
     if (p) {
@@ -97,7 +98,7 @@ module.exports = class Bitfield {
       let p = this._pages.get(i)
 
       if (!p && val) {
-        p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32)))
+        p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(WORDS_PER_PAGE)))
       }
 
       const end = Math.min(j + length, BITS_PER_PAGE)

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -2,12 +2,15 @@ const BigSparseArray = require('big-sparse-array')
 const b4a = require('b4a')
 const quickbit = require('quickbit-universal')
 
+const BITS_PER_PAGE = 2097152
+const BYTES_PER_PAGE = BITS_PER_PAGE / 8
+
 class BitfieldPage {
   constructor (index, bitfield) {
     this.dirty = false
     this.index = index
     this.bitfield = bitfield
-    this.tree = new quickbit.Index(this.bitfield)
+    this.tree = quickbit.Index.from(this.bitfield)
   }
 
   get (index) {
@@ -15,11 +18,9 @@ class BitfieldPage {
   }
 
   set (index, val) {
-    const changed = quickbit.set(this.bitfield, index, val)
-
-    this.tree.update(index)
-
-    return changed
+    if (quickbit.set(this.bitfield, index, val)) {
+      this.tree.update(index)
+    }
   }
 
   setRange (start, length, val) {
@@ -29,16 +30,14 @@ class BitfieldPage {
     const n = i + Math.ceil(length / 32)
 
     while (i < n) this.tree.update(i++ * 32)
-
-    return true
   }
 
-  indexOf (val, position) {
-    return quickbit.indexOf(this.bitfield, val, position, this.tree)
+  findFirst (val, position) {
+    return quickbit.findFirst(this.bitfield, val, this.tree.skipFirst(!val, position))
   }
 
-  lastIndexOf (val, position) {
-    return quickbit.lastIndexOf(this.bitfield, val, position, this.tree)
+  findLast (val, position) {
+    return quickbit.findLast(this.bitfield, val, this.tree.skipLast(!val, position))
   }
 }
 
@@ -48,23 +47,22 @@ module.exports = class Bitfield {
     this.storage = storage
     this.resumed = !!(buf && buf.byteLength >= 4)
 
-    this._pageSize = 2097152
     this._pages = new BigSparseArray()
 
     const all = this.resumed
       ? new Uint32Array(buf.buffer, buf.byteOffset, Math.floor(buf.byteLength / 4))
-      : new Uint32Array(this._pageSize / 32)
+      : new Uint32Array(BITS_PER_PAGE / 32)
 
-    for (let i = 0; i < all.length; i += this._pageSize / 32) {
-      const bitfield = ensureSize(all.subarray(i, i + (this._pageSize / 32)), this._pageSize / 32)
-      const page = new BitfieldPage(i / (this._pageSize / 32), bitfield)
+    for (let i = 0; i < all.length; i += BITS_PER_PAGE / 32) {
+      const bitfield = ensureSize(all.subarray(i, i + (BITS_PER_PAGE / 32)), BITS_PER_PAGE / 32)
+      const page = new BitfieldPage(i / (BITS_PER_PAGE / 32), bitfield)
       this._pages.set(page.index, page)
     }
   }
 
   get (index) {
-    const j = index & (this._pageSize - 1)
-    const i = (index - j) / this._pageSize
+    const j = index & (BITS_PER_PAGE - 1)
+    const i = (index - j) / BITS_PER_PAGE
 
     const p = this._pages.get(i)
 
@@ -72,38 +70,46 @@ module.exports = class Bitfield {
   }
 
   set (index, val) {
-    const j = index & (this._pageSize - 1)
-    const i = (index - j) / this._pageSize
+    const j = index & (BITS_PER_PAGE - 1)
+    const i = (index - j) / BITS_PER_PAGE
 
     let p = this._pages.get(i)
 
     if (!p && val) {
-      p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(this._pageSize / 32)))
+      p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32)))
     }
 
-    if (p && p.set(j, val) && !p.dirty) {
-      p.dirty = true
-      this.unflushed.push(p)
+    if (p) {
+      p.set(j, val)
+
+      if (!p.dirty) {
+        p.dirty = true
+        this.unflushed.push(p)
+      }
     }
   }
 
   setRange (start, length, val) {
-    let j = start & (this._pageSize - 1)
-    let i = (start - j) / this._pageSize
+    let j = start & (BITS_PER_PAGE - 1)
+    let i = (start - j) / BITS_PER_PAGE
 
     while (length > 0) {
       let p = this._pages.get(i)
 
       if (!p && val) {
-        p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(this._pageSize / 32)))
+        p = this._pages.set(i, new BitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32)))
       }
 
-      const end = Math.min(j + length, this._pageSize)
+      const end = Math.min(j + length, BITS_PER_PAGE)
       const range = end - j
 
-      if (p && p.setRange(j, range, val) && !p.dirty) {
-        p.dirty = true
-        this.unflushed.push(p)
+      if (p) {
+        p.setRange(j, range, val)
+
+        if (!p.dirty) {
+          p.dirty = true
+          this.unflushed.push(p)
+        }
       }
 
       j = 0
@@ -112,18 +118,18 @@ module.exports = class Bitfield {
     }
   }
 
-  indexOf (val, position) {
-    let j = position & (this._pageSize - 1)
-    let i = (position - j) / this._pageSize
+  findFirst (val, position) {
+    let j = position & (BITS_PER_PAGE - 1)
+    let i = (position - j) / BITS_PER_PAGE
 
     while (i < this._pages.factor) {
       const p = this._pages.get(i)
 
       if (p) {
-        const index = p.indexOf(val, j)
+        const index = p.findFirst(val, j)
 
         if (index !== -1) {
-          return i * this._pageSize + index
+          return i * BITS_PER_PAGE + index
         }
       }
 
@@ -135,29 +141,29 @@ module.exports = class Bitfield {
   }
 
   firstSet (position) {
-    return this.indexOf(true, position)
+    return this.findFirst(true, position)
   }
 
   firstUnset (position) {
-    return this.indexOf(false, position)
+    return this.findFirst(false, position)
   }
 
-  lastIndexOf (val, position) {
-    let j = position & (this._pageSize - 1)
-    let i = (position - j) / this._pageSize
+  findLast (val, position) {
+    let j = position & (BITS_PER_PAGE - 1)
+    let i = (position - j) / BITS_PER_PAGE
 
     while (i >= 0) {
       const p = this._pages.get(i)
 
       if (p) {
-        const index = p.lastIndexOf(val, j)
+        const index = p.findLast(val, j)
 
         if (index !== -1) {
-          return i * this._pageSize + index
+          return i * BITS_PER_PAGE + index
         }
       }
 
-      j = this._pageSize - 1
+      j = BITS_PER_PAGE - 1
       i--
     }
 
@@ -165,16 +171,16 @@ module.exports = class Bitfield {
   }
 
   lastSet (position) {
-    return this.lastIndexOf(true, position)
+    return this.findLast(true, position)
   }
 
   lastUnset (position) {
-    return this.lastIndexOf(false, position)
+    return this.findLast(false, position)
   }
 
   * want (start, length) {
-    const j = start & (this._pageSize - 1)
-    let i = (start - j) / this._pageSize
+    const j = start & (BITS_PER_PAGE - 1)
+    let i = (start - j) / BITS_PER_PAGE
 
     while (length > 0) {
       const p = this._pages.get(i)
@@ -182,16 +188,16 @@ module.exports = class Bitfield {
       if (p) {
         // We always send at least 4 KiB worth of bitfield in a want, rounding
         // to the nearest 4 KiB.
-        const end = ceilTo(clamp(length / 8, 4096, this._pageSize / 8), 4096)
+        const end = ceilTo(clamp(length / 8, 4096, BYTES_PER_PAGE), 4096)
 
         yield {
-          start: i * this._pageSize,
+          start: i * BITS_PER_PAGE,
           bitfield: p.bitfield.subarray(0, end / 4)
         }
       }
 
       i++
-      length -= this._pageSize
+      length -= BITS_PER_PAGE
     }
   }
 
@@ -231,7 +237,7 @@ module.exports = class Bitfield {
         )
 
         page.dirty = false
-        this.storage.write(page.index * (this._pageSize / 8), buf, done)
+        this.storage.write(page.index * BYTES_PER_PAGE, buf, done)
       }
 
       function done (err) {

--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -123,7 +123,7 @@ module.exports = class Bitfield {
     let j = position & (BITS_PER_PAGE - 1)
     let i = (position - j) / BITS_PER_PAGE
 
-    while (i < this._pages.factor) {
+    while (i < this._pages.maxLength) {
       const p = this._pages.get(i)
 
       if (p) {

--- a/lib/compat.js
+++ b/lib/compat.js
@@ -1,0 +1,11 @@
+// Export the appropriate version of `quickbit-universal` as the plain import
+// may resolve to an older version in some environments
+let quickbit = require('quickbit-universal')
+if (
+  typeof quickbit.findFirst !== 'function' ||
+  typeof quickbit.findLast !== 'function'
+) {
+  // This should always load the fallback from the locally installed version
+  quickbit = require('quickbit-universal/fallback')
+}
+exports.quickbit = quickbit

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -1,5 +1,5 @@
 const BigSparseArray = require('big-sparse-array')
-const quickbit = require('quickbit-universal')
+const quickbit = require('./compat').quickbit
 
 const BITS_PER_PAGE = 32768
 const BYTES_PER_PAGE = BITS_PER_PAGE / 8

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -1,41 +1,127 @@
 const BigSparseArray = require('big-sparse-array')
 const quickbit = require('quickbit-universal')
 
-module.exports = class RemoteBitfield {
-  constructor () {
-    this._pageSize = 32768
-    this._pages = new BigSparseArray()
+const BITS_PER_PAGE = 32768
+const BYTES_PER_PAGE = BITS_PER_PAGE / 8
+const BITS_PER_SEGMENT = 2097152
+const BYTES_PER_SEGMENT = BITS_PER_SEGMENT / 8
+const PAGES_PER_SEGMENT = BITS_PER_SEGMENT / BITS_PER_PAGE
+
+class RemoteBitfieldPage {
+  constructor (index, bitfield, segment) {
+    this.index = index
+    this.bitfield = bitfield
+    this.segment = segment
+    this.offset = index * BYTES_PER_PAGE - segment.index * BYTES_PER_SEGMENT
+
+    segment.add(this)
+  }
+
+  get tree () {
+    return this.segment.tree
   }
 
   get (index) {
-    const j = index & (this._pageSize - 1)
-    const i = (index - j) / this._pageSize
-
-    const p = this._pages.get(i)
-
-    return p ? quickbit.get(p, j) : false
+    return quickbit.get(this.bitfield, index)
   }
 
   set (index, val) {
-    const j = index & (this._pageSize - 1)
-    const i = (index - j) / this._pageSize
-
-    const p = this._pages.get(i) || this._pages.set(i, new Uint32Array(this._pageSize / 32))
-
-    quickbit.set(p, j, val)
+    if (quickbit.set(this.bitfield, index, val)) {
+      this.tree.update(this.offset * 8 + index)
+    }
   }
 
   setRange (start, length, val) {
-    let j = start & (this._pageSize - 1)
-    let i = (start - j) / this._pageSize
+    quickbit.fill(this.bitfield, val, start, start + length)
+
+    let i = Math.floor(start / 32)
+    const n = i + Math.ceil(length / 32)
+
+    while (i < n) this.tree.update(this.offset * 8 + i++ * 32)
+  }
+
+  insert (start, bitfield) {
+    this.bitfield.set(bitfield, start / 32)
+  }
+}
+
+class RemoteBitfieldSegment {
+  constructor (index) {
+    this.index = index
+    this.tree = quickbit.Index.from([])
+  }
+
+  get chunks () {
+    return this.tree.chunks
+  }
+
+  add (page) {
+    let j = -1
+    let i = this.chunks.length
+
+    while (j + 1 < i) {
+      const m = j + ((i - j) >>> 1)
+
+      if (page.index < this.chunks[m].index) {
+        i = m
+      } else {
+        j = m
+      }
+    }
+
+    this.chunks.splice(i, 0, { field: page.bitfield, offset: page.offset })
+  }
+}
+
+module.exports = class RemoteBitfield {
+  constructor () {
+    this._pages = new BigSparseArray()
+    this._segments = new BigSparseArray()
+  }
+
+  get (index) {
+    const j = index & (BITS_PER_PAGE - 1)
+    const i = (index - j) / BITS_PER_PAGE
+
+    const p = this._pages.get(i)
+
+    return p ? p.get(j) : false
+  }
+
+  set (index, val) {
+    const j = index & (BITS_PER_PAGE - 1)
+    const i = (index - j) / BITS_PER_PAGE
+
+    let p = this._pages.get(i)
+
+    if (!p && val) {
+      const k = i / PAGES_PER_SEGMENT | 0
+      const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+
+      p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+    }
+
+    if (p) p.set(j, val)
+  }
+
+  setRange (start, length, val) {
+    let j = start & (BITS_PER_PAGE - 1)
+    let i = (start - j) / BITS_PER_PAGE
 
     while (length > 0) {
-      const p = this._pages.get(i) || this._pages.set(i, new Uint32Array(this._pageSize / 32))
+      let p = this._pages.get(i)
 
-      const end = Math.min(j + length, this._pageSize)
+      if (!p && val) {
+        const k = i / PAGES_PER_SEGMENT | 0
+        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+
+        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+      }
+
+      const end = Math.min(j + length, BITS_PER_PAGE)
       const range = end - j
 
-      quickbit.fill(p, val, j, end)
+      if (p) p.setRange(j, range, val)
 
       j = 0
       i++
@@ -48,16 +134,23 @@ module.exports = class RemoteBitfield {
 
     let length = bitfield.byteLength * 8
 
-    let j = start & (this._pageSize - 1)
-    let i = (start - j) / this._pageSize
+    let j = start & (BITS_PER_PAGE - 1)
+    let i = (start - j) / BITS_PER_PAGE
 
     while (length > 0) {
-      const p = this._pages.get(i) || this._pages.set(i, new Uint32Array(this._pageSize / 32))
+      let p = this._pages.get(i)
 
-      const end = Math.min(j + length, this._pageSize)
+      if (!p) {
+        const k = i / PAGES_PER_SEGMENT | 0
+        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+
+        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+      }
+
+      const end = Math.min(j + length, BITS_PER_PAGE)
       const range = end - j
 
-      p.set(bitfield.subarray(0, range / 32), j / 32)
+      p.insert(j, bitfield.subarray(0, range / 32))
 
       bitfield = bitfield.subarray(range / 32)
 

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -3,6 +3,7 @@ const quickbit = require('quickbit-universal')
 
 const BITS_PER_PAGE = 32768
 const BYTES_PER_PAGE = BITS_PER_PAGE / 8
+const WORDS_PER_PAGE = BYTES_PER_PAGE / 4
 const BITS_PER_SEGMENT = 2097152
 const BYTES_PER_SEGMENT = BITS_PER_SEGMENT / 8
 const PAGES_PER_SEGMENT = BITS_PER_SEGMENT / BITS_PER_PAGE
@@ -64,20 +65,16 @@ class RemoteBitfieldSegment {
   }
 
   add (page) {
-    let j = -1
-    let i = this.chunks.length
+    const chunk = { field: page.bitfield, offset: page.offset }
 
-    while (j + 1 < i) {
-      const m = j + ((i - j) >>> 1)
+    this.chunks.push(chunk)
 
-      if (page.index < this.chunks[m].index) {
-        i = m
-      } else {
-        j = m
-      }
+    for (let i = this.chunks.length - 2; i >= 0; i--) {
+      const prev = this.chunks[i]
+      if (prev.offset <= chunk.offset) break
+      this.chunks[i] = chunk
+      this.chunks[i + 1] = prev
     }
-
-    this.chunks.splice(i, 0, { field: page.bitfield, offset: page.offset })
   }
 }
 
@@ -106,7 +103,7 @@ module.exports = class RemoteBitfield {
       const k = i / PAGES_PER_SEGMENT | 0
       const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
-      p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+      p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))
     }
 
     if (p) p.set(j, val)
@@ -123,7 +120,7 @@ module.exports = class RemoteBitfield {
         const k = i / PAGES_PER_SEGMENT | 0
         const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
-        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))
       }
 
       const end = Math.min(j + length, BITS_PER_PAGE)
@@ -212,7 +209,7 @@ module.exports = class RemoteBitfield {
         const k = i / PAGES_PER_SEGMENT | 0
         const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
-        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
+        p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))
       }
 
       const end = Math.min(j + length, BITS_PER_PAGE)

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -40,6 +40,14 @@ class RemoteBitfieldPage {
     while (i < n) this.tree.update(this.offset * 8 + i++ * 32)
   }
 
+  findFirst (val, position) {
+    return quickbit.findFirst(this.bitfield, val, this.tree.skipFirst(!val, this.offset * 8 + position))
+  }
+
+  findLast (val, position) {
+    return quickbit.findLast(this.bitfield, val, this.tree.skipLast(!val, this.offset * 8 + position))
+  }
+
   insert (start, bitfield) {
     this.bitfield.set(bitfield, start / 32)
   }
@@ -127,6 +135,66 @@ module.exports = class RemoteBitfield {
       i++
       length -= range
     }
+  }
+
+  findFirst (val, position) {
+    let j = position & (BITS_PER_PAGE - 1)
+    let i = (position - j) / BITS_PER_PAGE
+
+    while (i < this._pages.maxLength) {
+      const p = this._pages.get(i)
+
+      if (p) {
+        const index = p.findFirst(val, j)
+
+        if (index !== -1) {
+          return i * BITS_PER_PAGE + index
+        }
+      }
+
+      j = 0
+      i++
+    }
+
+    return -1
+  }
+
+  firstSet (position) {
+    return this.findFirst(true, position)
+  }
+
+  firstUnset (position) {
+    return this.findFirst(false, position)
+  }
+
+  findLast (val, position) {
+    let j = position & (BITS_PER_PAGE - 1)
+    let i = (position - j) / BITS_PER_PAGE
+
+    while (i >= 0) {
+      const p = this._pages.get(i)
+
+      if (p) {
+        const index = p.findLast(val, j)
+
+        if (index !== -1) {
+          return i * BITS_PER_PAGE + index
+        }
+      }
+
+      j = BITS_PER_PAGE - 1
+      i--
+    }
+
+    return -1
+  }
+
+  lastSet (position) {
+    return this.findLast(true, position)
+  }
+
+  lastUnset (position) {
+    return this.findLast(false, position)
   }
 
   insert (start, bitfield) {

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -96,7 +96,7 @@ module.exports = class RemoteBitfield {
 
     if (!p && val) {
       const k = i / PAGES_PER_SEGMENT | 0
-      const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+      const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
       p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
     }
@@ -113,7 +113,7 @@ module.exports = class RemoteBitfield {
 
       if (!p && val) {
         const k = i / PAGES_PER_SEGMENT | 0
-        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
         p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
       }
@@ -142,7 +142,7 @@ module.exports = class RemoteBitfield {
 
       if (!p) {
         const k = i / PAGES_PER_SEGMENT | 0
-        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(i))
+        const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
         p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(BITS_PER_PAGE / 32), s))
       }

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -11,9 +11,9 @@ const PAGES_PER_SEGMENT = BITS_PER_SEGMENT / BITS_PER_PAGE
 class RemoteBitfieldPage {
   constructor (index, bitfield, segment) {
     this.index = index
+    this.offset = index * BYTES_PER_PAGE - segment.offset
     this.bitfield = bitfield
     this.segment = segment
-    this.offset = index * BYTES_PER_PAGE - segment.index * BYTES_PER_SEGMENT
 
     segment.add(this)
   }
@@ -42,11 +42,11 @@ class RemoteBitfieldPage {
   }
 
   findFirst (val, position) {
-    return quickbit.findFirst(this.bitfield, val, this.tree.skipFirst(!val, this.offset * 8 + position))
+    return quickbit.findFirst(this.bitfield, val, position)
   }
 
   findLast (val, position) {
-    return quickbit.findLast(this.bitfield, val, this.tree.skipLast(!val, this.offset * 8 + position))
+    return quickbit.findLast(this.bitfield, val, position)
   }
 
   insert (start, bitfield) {
@@ -57,7 +57,9 @@ class RemoteBitfieldPage {
 class RemoteBitfieldSegment {
   constructor (index) {
     this.index = index
+    this.offset = index * BYTES_PER_SEGMENT
     this.tree = quickbit.Index.from([])
+    this.pages = new Array(64)
   }
 
   get chunks () {
@@ -65,6 +67,8 @@ class RemoteBitfieldSegment {
   }
 
   add (page) {
+    this.pages[page.index - this.index * 64] = page
+
     const chunk = { field: page.bitfield, offset: page.offset }
 
     this.chunks.push(chunk)
@@ -75,6 +79,48 @@ class RemoteBitfieldSegment {
       this.chunks[i] = chunk
       this.chunks[i + 1] = prev
     }
+  }
+
+  findFirst (val, position) {
+    position = this.tree.skipFirst(!val, position)
+
+    const j = position & (BITS_PER_PAGE - 1)
+    const i = (position - j) / BITS_PER_PAGE
+
+    if (i >= 64) return -1
+
+    const p = this.pages[i]
+
+    if (p) {
+      const index = p.findFirst(val, j)
+
+      if (index !== -1) {
+        return i * BITS_PER_PAGE + index
+      }
+    }
+
+    return -1
+  }
+
+  findLast (val, position) {
+    position = this.tree.skipLast(!val, position)
+
+    const j = position & (BITS_PER_PAGE - 1)
+    const i = (position - j) / BITS_PER_PAGE
+
+    if (i >= 64) return -1
+
+    const p = this.pages[i]
+
+    if (p) {
+      const index = p.findLast(val, j)
+
+      if (index !== -1) {
+        return i * BITS_PER_PAGE + index
+      }
+    }
+
+    return -1
   }
 }
 
@@ -135,17 +181,17 @@ module.exports = class RemoteBitfield {
   }
 
   findFirst (val, position) {
-    let j = position & (BITS_PER_PAGE - 1)
-    let i = (position - j) / BITS_PER_PAGE
+    let j = position & (BITS_PER_SEGMENT - 1)
+    let i = (position - j) / BITS_PER_SEGMENT
 
-    while (i < this._pages.maxLength) {
-      const p = this._pages.get(i)
+    while (i < this._segments.maxLength) {
+      const s = this._segments.get(i)
 
-      if (p) {
-        const index = p.findFirst(val, j)
+      if (s) {
+        const index = s.findFirst(val, j)
 
         if (index !== -1) {
-          return i * BITS_PER_PAGE + index
+          return i * BITS_PER_SEGMENT + index
         }
       }
 
@@ -165,21 +211,21 @@ module.exports = class RemoteBitfield {
   }
 
   findLast (val, position) {
-    let j = position & (BITS_PER_PAGE - 1)
-    let i = (position - j) / BITS_PER_PAGE
+    let j = position & (BITS_PER_SEGMENT - 1)
+    let i = (position - j) / BITS_PER_SEGMENT
 
     while (i >= 0) {
-      const p = this._pages.get(i)
+      const s = this._segments.get(i)
 
-      if (p) {
-        const index = p.findLast(val, j)
+      if (s) {
+        const index = s.findLast(val, j)
 
         if (index !== -1) {
-          return i * BITS_PER_PAGE + index
+          return i * BITS_PER_SEGMENT + index
         }
       }
 
-      j = BITS_PER_PAGE - 1
+      j = BITS_PER_SEGMENT - 1
       i--
     }
 

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -100,7 +100,7 @@ module.exports = class RemoteBitfield {
     let p = this._pages.get(i)
 
     if (!p && val) {
-      const k = i / PAGES_PER_SEGMENT | 0
+      const k = Math.floor(i / PAGES_PER_SEGMENT)
       const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
       p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))
@@ -117,7 +117,7 @@ module.exports = class RemoteBitfield {
       let p = this._pages.get(i)
 
       if (!p && val) {
-        const k = i / PAGES_PER_SEGMENT | 0
+        const k = Math.floor(i / PAGES_PER_SEGMENT)
         const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
         p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))
@@ -206,7 +206,7 @@ module.exports = class RemoteBitfield {
       let p = this._pages.get(i)
 
       if (!p) {
-        const k = i / PAGES_PER_SEGMENT | 0
+        const k = Math.floor(i / PAGES_PER_SEGMENT)
         const s = this._segments.get(k) || this._segments.set(k, new RemoteBitfieldSegment(k))
 
         p = this._pages.set(i, new RemoteBitfieldPage(i, new Uint32Array(WORDS_PER_PAGE), s))

--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -59,7 +59,7 @@ class RemoteBitfieldSegment {
     this.index = index
     this.offset = index * BYTES_PER_SEGMENT
     this.tree = quickbit.Index.from([])
-    this.pages = new Array(64)
+    this.pages = new Array(PAGES_PER_SEGMENT)
   }
 
   get chunks () {
@@ -67,7 +67,7 @@ class RemoteBitfieldSegment {
   }
 
   add (page) {
-    this.pages[page.index - this.index * 64] = page
+    this.pages[page.index - this.index * PAGES_PER_SEGMENT] = page
 
     const chunk = { field: page.bitfield, offset: page.offset }
 
@@ -87,7 +87,7 @@ class RemoteBitfieldSegment {
     const j = position & (BITS_PER_PAGE - 1)
     const i = (position - j) / BITS_PER_PAGE
 
-    if (i >= 64) return -1
+    if (i >= PAGES_PER_SEGMENT) return -1
 
     const p = this.pages[i]
 
@@ -108,7 +108,7 @@ class RemoteBitfieldSegment {
     const j = position & (BITS_PER_PAGE - 1)
     const i = (position - j) / BITS_PER_PAGE
 
-    if (i >= 64) return -1
+    if (i >= PAGES_PER_SEGMENT) return -1
 
     const p = this.pages[i]
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hypercore-crypto": "^3.2.1",
     "is-options": "^1.0.1",
     "protomux": "^3.4.0",
-    "quickbit-universal": "^2.0.1",
+    "quickbit-universal": "^2.0.2",
     "random-access-file": "^4.0.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hypercore-crypto": "^3.2.1",
     "is-options": "^1.0.1",
     "protomux": "^3.4.0",
-    "quickbit-universal": "^1.3.0",
+    "quickbit-universal": "^2.0.1",
     "random-access-file": "^4.0.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",

--- a/test/remote-bitfield.js
+++ b/test/remote-bitfield.js
@@ -1,0 +1,10 @@
+const test = require('brittle')
+const RemoteBitfield = require('../lib/remote-bitfield')
+
+test('remote bitfield - findFirst', function (t) {
+  const b = new RemoteBitfield()
+
+  b.set(1000000, true)
+
+  t.is(b.findFirst(true, 0), 1000000)
+})


### PR DESCRIPTION
This PR implements remote bitfield indexing using the new sparse indexing capabilities of Quickbit (https://github.com/holepunchto/libquickbit#sparse-fields). The remote bitfield now maintains a list of segments, each with an index that covers 64 x 4096 KiB pages. Each page is assigned a byte offset within its corresponding segment to translate bit positions to and from the sparse 256 KiB bitfield covered by its segment.