### PR TITLE
Update `quickbit-universal`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hypercore-crypto": "^3.2.1",
     "is-options": "^1.0.1",
     "protomux": "^3.4.0",
-    "quickbit-universal": "^2.0.2",
+    "quickbit-universal": "^2.0.3",
     "random-access-file": "^4.0.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",


### PR DESCRIPTION
The latest patch release makes use of the new `allo`/`allz` functions with SSE 4.1 implementations on Intel, bringing performance on Intel on par with ARM.