### PR TITLE
Don't read empty disk pages when loading bitfield

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -251,12 +251,13 @@ module.exports = class Bitfield {
     })
   }
 
-  static open (storage) {
+  static open (storage, tree = null) {
     return new Promise((resolve, reject) => {
       storage.stat((err, st) => {
         if (err) return resolve(new Bitfield(storage, null))
-        const size = st.size - (st.size & 3)
+        let size = st.size - (st.size & 3)
         if (!size) return resolve(new Bitfield(storage, null))
+        if (tree) size = Math.min(size, ceilTo(tree.length / 8, 4096))
         storage.read(0, size, (err, data) => {
           if (err) return reject(err)
           resolve(new Bitfield(storage, data))

--- a/lib/core.js
+++ b/lib/core.js
@@ -108,7 +108,7 @@ module.exports = class Core {
     }
 
     const tree = await MerkleTree.open(treeFile, { crypto, ...header.tree })
-    const bitfield = await Bitfield.open(bitfieldFile)
+    const bitfield = await Bitfield.open(bitfieldFile, tree)
     const blocks = new BlockStore(dataFile, tree)
 
     if (overwrite) {


### PR DESCRIPTION
When loading the bitfield from disk, pass the tree and only load up to its length ceiled to a multiple of 4 KiB.